### PR TITLE
Add function to look up CCC directly from u32

### DIFF
--- a/src/canonical_combining_class.rs
+++ b/src/canonical_combining_class.rs
@@ -13,15 +13,7 @@ const SHIFT: usize = MASK.count_ones() as usize;
 /// assert_eq!(get_canonical_combining_class('ི'), CanonicalCombiningClass::CCC130);
 /// ```
 pub fn get_canonical_combining_class(chr: char) -> CanonicalCombiningClass {
-    let u = chr as u32;
-
-    if u <= LAST_CODEPOINT {
-        CANONICAL_COMBINING_CLASS_BLOCKS[CANONICAL_COMBINING_CLASS_BLOCK_OFFSETS
-            [u as usize >> SHIFT] as usize
-            + (u as usize & MASK)]
-    } else {
-        NotReordered
-    }
+    get_canonical_combining_class_u32(chr as u32)
 }
 
 /// Look up the canonical combining class for the character represented by a `u32` value. If there

--- a/src/canonical_combining_class.rs
+++ b/src/canonical_combining_class.rs
@@ -23,3 +23,25 @@ pub fn get_canonical_combining_class(chr: char) -> CanonicalCombiningClass {
         NotReordered
     }
 }
+
+/// Look up the canonical combining class for the character represented by a `u32` value. If there
+/// is no such character, the default combining class, `NotReordered` (`== 0`), will be returned.
+///
+/// ### Example
+///
+/// ```
+/// use unicode_canonical_combining_class::{
+///   get_canonical_combining_class_u32, CanonicalCombiningClass
+/// };
+///
+/// assert_eq!(get_canonical_combining_class_u32(0x0F72), CanonicalCombiningClass::CCC130);
+/// ```
+pub fn get_canonical_combining_class_u32(u: u32) -> CanonicalCombiningClass {
+    if u <= LAST_CODEPOINT {
+        CANONICAL_COMBINING_CLASS_BLOCKS[CANONICAL_COMBINING_CLASS_BLOCK_OFFSETS
+            [u as usize >> SHIFT] as usize
+            + (u as usize & MASK)]
+    } else {
+        NotReordered
+    }
+}

--- a/src/canonical_combining_class.rs
+++ b/src/canonical_combining_class.rs
@@ -31,7 +31,7 @@ pub fn get_canonical_combining_class(chr: char) -> CanonicalCombiningClass {
 ///
 /// ```
 /// use unicode_canonical_combining_class::{
-///   get_canonical_combining_class_u32, CanonicalCombiningClass
+///     get_canonical_combining_class_u32, CanonicalCombiningClass,
 /// };
 ///
 /// assert_eq!(get_canonical_combining_class_u32(0x0F72), CanonicalCombiningClass::CCC130);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,9 @@
 mod canonical_combining_class;
 mod tables;
 
-pub use canonical_combining_class::get_canonical_combining_class;
+pub use canonical_combining_class::{
+    get_canonical_combining_class, get_canonical_combining_class_u32,
+};
 pub use tables::CanonicalCombiningClass;
 
 /// The version of [Unicode](http://www.unicode.org/)
@@ -22,7 +24,9 @@ pub const UNICODE_VERSION: (u64, u64, u64) = (14, 0, 0);
 
 #[cfg(test)]
 mod test {
-    use super::{get_canonical_combining_class, CanonicalCombiningClass};
+    use super::{
+        get_canonical_combining_class, get_canonical_combining_class_u32, CanonicalCombiningClass,
+    };
 
     #[test]
     fn test_get_canonical_combining_class() {
@@ -72,6 +76,58 @@ mod test {
         );
         assert_eq!(
             get_canonical_combining_class('\u{1259}'),
+            CanonicalCombiningClass::NotReordered
+        );
+    }
+
+    #[test]
+    fn test_get_canonical_combining_class_u32() {
+        assert_eq!(
+            get_canonical_combining_class_u32(0x05B0),
+            CanonicalCombiningClass::CCC10
+        );
+        assert_eq!(
+            get_canonical_combining_class_u32(0x08F0),
+            CanonicalCombiningClass::CCC27
+        );
+        assert_eq!(
+            get_canonical_combining_class_u32(0x0670),
+            CanonicalCombiningClass::CCC35
+        );
+        assert_eq!(
+            get_canonical_combining_class_u32(0x0E39),
+            CanonicalCombiningClass::CCC103
+        );
+        assert_eq!(
+            get_canonical_combining_class_u32(0x0E48),
+            CanonicalCombiningClass::CCC107
+        );
+        assert_eq!(
+            get_canonical_combining_class_u32(0x1DCE),
+            CanonicalCombiningClass::AttachedAbove
+        );
+        assert_eq!(
+            get_canonical_combining_class_u32(0x0F39),
+            CanonicalCombiningClass::AttachedAboveRight
+        );
+        assert_eq!(
+            get_canonical_combining_class_u32(0x0359),
+            CanonicalCombiningClass::Below
+        );
+        assert_eq!(
+            get_canonical_combining_class_u32(0x1939),
+            CanonicalCombiningClass::BelowRight
+        );
+        assert_eq!(
+            get_canonical_combining_class_u32(0xABED),
+            CanonicalCombiningClass::Virama
+        );
+        assert_eq!(
+            get_canonical_combining_class_u32(0x081A),
+            CanonicalCombiningClass::NotReordered
+        );
+        assert_eq!(
+            get_canonical_combining_class_u32(0x1259),
             CanonicalCombiningClass::NotReordered
         );
     }


### PR DESCRIPTION
This should be pretty self-explanatory—though whether you want it in the library is a different question.

The original function already does what it's supposed to (return `NotReordered`) if you pass it an invalid `char` generated from a `u32` with the unsafe method. This would simply cut out the middleman. I've found myself running `char::from_u32_unchecked` just to get a `char` to fetch the CCC, and that seems silly, given that the lookup function immediately casts it back.

Anyway, I added the new function, gave it a bit of documentation, and duplicated the existing tests. I haven't done anything with the readme or the module docs. Thanks!